### PR TITLE
Docker-compose pour dockerize l'api

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -8,7 +8,7 @@ RUN apk update \
     && rm -rf /var/cache/apk/* \
     # Create empty project
     && cargo new --bin app
-WORKDIR ./app
+WORKDIR /app
 
 # Cache cargo dependencies
 COPY ./packages/server/Cargo.toml ./Cargo.lock ./
@@ -29,6 +29,3 @@ COPY --from=builder \
     /usr/src/app/server
 
 ENV ROCKET_ADDRESS=0.0.0.0
-EXPOSE 8000
-
-CMD ["/usr/src/app/server"]

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Le passeport vaccinal pour les hackathons
 - Run the server with `./run.sh server`
 
 #### Build and run the server with Docker
-- `docker build -t hxbuddy-api -f Dockerfile.server .`
-- `docker run --rm -p 8000:8000 hxbuddy-api`
+
+- `docker-compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  api:
+    container_name: hxbuddy-api
+    image: hxbuddy-api:1.0.0
+    build:
+      context: .
+      dockerfile: ./Dockerfile.server
+    command: ./usr/src/app/server
+    ports:
+      - 8000:8000
+    volumes:
+      - /app
+    restart: unless-stopped


### PR DESCRIPTION
J'ai utilisé docker-compose en plus de docker, ca permet d'avoir une manière plus high level pour gérer le container, et ca fait que maintenant on a juste besoin de faire `docker-compose up` pour faire rouler le serveur dans un container.